### PR TITLE
Fix for webOS 3.0 + Workflows to produce artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,38 @@
+name: package
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: apt-get install
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: sudo apt-get update && sudo apt-get dist-upgrade -y && sudo apt-get install -y npm
+    - name: npm install
+      run: npm install
+    - name: npm build
+      run: npm run build
+    - name: npm package
+      run: npm run package
+    - name: get ipk artifact name
+      id: ipk
+      run: |
+        GIT_COMMIT=$(git rev-parse --short HEAD)
+        PREFIX=$(basename $(ls -1 *.ipk) .ipk)
+        echo "zip=$PREFIX-$GIT_COMMIT.zip" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.ipk.outputs.zip }}
+        path: '*.ipk'
+        retention-days: 30

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         GIT_COMMIT=$(git rev-parse --short HEAD)
         PREFIX=$(basename $(ls -1 *.ipk) .ipk)
-        echo "zip=$PREFIX-$GIT_COMMIT.zip" >> "$GITHUB_OUTPUT"
+        echo "zip=$PREFIX-$GIT_COMMIT" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.ipk.outputs.zip }}

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -23,7 +23,7 @@ async function retry(attempt, cb) {
       return await cb();
     } catch (err) {
       if (attempt--) {
-        log (`An error occured, ${attempt} tries left...`);
+        log (`... failed (${err.message}), ${attempt} tries left`);
         continue;
       }
       throw err;
@@ -35,86 +35,136 @@ function log(s) {
   document.querySelector('pre').innerText += `[${new Date()}] ${s}\n`;
 }
 
-(async () => {
-  // always launch autostart first because even if we fail later,
-  // at least everything will have started (including SSH)
-  log("Launching autostart...");
-  const res2 = await lunaCall('luna://org.webosbrew.hbchannel.service/autostart', {});
-  log(`Result: ${res2.message}`);
-
-  // now all that we want is ensuring that we get started on next boot,
-  // all the logic below is here to ensure this is the case
-
-  try {
-    // unregister (always succeeds, even if we weren't registered),
-    // then register the app in the real /var/lib/eim
-    log('Unregistering ourselves as input app...');
-    await lunaCall('luna://com.webos.service.eim/deleteDevice', {
-      appId: 'org.webosbrew.autostart',
-    });
-  } catch (err) {
-    log(`An error occurred, but carrying on:\n${err.stack}`);
-  }
-
-  try {
-    log('Registering ourselves as input app...');
-    await lunaCall('luna://com.webos.service.eim/addDevice', {
-      appId: 'org.webosbrew.autostart',
-      pigImage: '',
-      mvpdIcon: '',
-      type: 'MVPD_IP', // can be either MVPD_IP or MVPD_RF, required for webOS 3.x
-      label: 'Autostart', // required for webOS 3.x
-      description: 'webosbrew autostart', // required for webOS 3.x
-    });
-  } catch (err) {
-    const errData = JSON.parse(err.message);
-    if (errData.errorCode === 'EIM.105') { // input app already registered
-      log('Already registered, good, carrying on...');
+function logres(res) {
+  if (res.returnValue) {
+    if (res.message) {
+      log(`... success (${res.message})`);
     }
     else {
-      log(`An error occured:\n${err.stack}`);
-      return;
+      log('... success');
     }
+  }
+  else {
+    log(`... failed (${res.message})`);
+  }
+}
+
+(async () => {
+
+  /* We'll do a certain number of luna calls.
+     On startup, sometimes these calls fail (bus overload?),
+     so we'll retry them 3 times if we get an error.
+     Each call usually take between 0 and 10 seconds. */
+
+  try {
+  /* Be polite and launch the actual previous input app, if any.
+     This'll give back control to the user while we finish our setup
+     in the background, as the whole process can be slow due to luna calls
+     and the number of other processes competing for CPU on startup. */
+    await retry(3, async () => {
+      log("Checking last input app...");
+      const lastinput = await lunaCall('luna://org.webosbrew.hbchannel.service/exec', {
+        command: 'cat /var/lib/eim/lastinput',
+      });
+      if (lastinput.stdoutString) {
+        const lastinputPayload = JSON.parse(lastinput.stdoutString);
+        if (lastinputPayload.appId) {
+          log(`Last input app: ${lastinputPayload.appId}`);
+          if (lastinputPayload.appId !== 'org.webosbrew.autostart') {
+            log("Relaunching this app...");
+            const res = await lunaCall('luna://com.webos.service.applicationManager/launch', {
+              id: lastinputPayload.appId,
+            });
+            logres(res);
+          }
+        }
+      }
+      else {
+        log("No app to relaunch.");
+      }
+    });
+  } catch (err) {
+    log(`Couldn't start last input app but carrying on:\n${err.stack}`);
   }
 
   try {
+  /* Launch autostart soon in the process because even if we fail later down,
+     at least everything will have started (including SSH). */
     await retry(3, async () => {
-      // now setup an eim overlay so that any changes done later don't erase our own app
-      // if /var/lib/webosbrew/eim already exists, keep it that way, changes done in previous
-      // sessions will live here, so just bind mount it, otherwise create it from the /var/lib/eim contents
+      log("Launching autostart...");
+      const res = await lunaCall('luna://org.webosbrew.hbchannel.service/autostart', {});
+      logres(res);
+    });
+  } catch (err) {
+    log(`Couldn't run autostart, but carrying on:\n${err.stack}`);
+  }
+
+  /* Now, all that we want is ensuring that we get started on next boot,
+     all the logic below is here to ensure this is the case. */
+
+  try {
+    /* First, unregister (always succeeds, even if we weren't registered),
+       this is needed because we'll get started only on the boot following
+       a successful addDevice, and this only succeeds if we're not already in the list. */
+    await retry(3, async () => {
+      log('Unregistering ourselves as input app...');
+      const res = await lunaCall('luna://com.webos.service.eim/deleteDevice', {
+        appId: 'org.webosbrew.autostart',
+      });
+      logres(res);
+    });
+  } catch (err) {
+    log(`Couldn't unregister, but carrying on:\n${err.stack}`);
+  }
+
+  try {
+    // Register again to ensure we're started on next boot.
+    await retry(3, async () => {
+      log('Registering ourselves as input app...');
+      const res = await lunaCall('luna://com.webos.service.eim/addDevice', {
+        appId: 'org.webosbrew.autostart',
+        pigImage: '',
+        mvpdIcon: '',
+        type: 'MVPD_IP', // can be either MVPD_IP or MVPD_RF, required for webOS 3.4 at least
+        label: 'Autostart', // required for webOS 3.4 at least
+        description: 'webosbrew autostart', // required for webOS 3.4 at least
+      });
+      logres(res);
+    });
+  } catch (err) {
+    log(`Couldn't register, but carrying on:\n${err.stack}`);
+  }
+
+  try {
+    /* Now, setup an eim overlay so that any changes done later don't erase our own app
+       if /var/lib/webosbrew/eim already exists, keep it that way, changes done in previous
+       sessions will live here, so just bind mount it, otherwise create it
+       from the /var/lib/eim contents. */
+    await retry(3, async () => {
       log('Setting up eim overlay...');
       const res = await lunaCall('luna://org.webosbrew.hbchannel.service/exec', {
         command: 'if [[ ! -d /var/lib/webosbrew/eim ]]; then cp -r /var/lib/eim /var/lib/webosbrew/eim && echo cp ok || echo cp failed; fi ; if ! findmnt /var/lib/eim; then mount --bind /var/lib/webosbrew/eim /var/lib/eim && echo mount overlay ok || echo mount overlay failed; fi',
       });
       log(`Result: ${res.stdoutString} ${res.stderrString}`);
     });
-
-    // this just removes ourselves from the overlay, but we still live in the real /var/lib/eim,
-    // which guarantees that we'll survive on the next reboot
-    log("Removing our own input app from eim overlay...");
-    await lunaCall('luna://com.webos.service.eim/deleteDevice', {
-      appId: 'org.webosbrew.autostart',
-    });
-
-    // now be polite and launch the actual previous input app, if any
-    log("Checking last input app...");
-    const lastinput = await lunaCall('luna://org.webosbrew.hbchannel.service/exec', {
-      command: 'cat /var/lib/eim/lastinput',
-    });
-    if (lastinput.stdoutString) {
-      const lastinputPayload = JSON.parse(lastinput.stdoutString);
-      if (lastinputPayload.appId) {
-        log(`Last input app: ${lastinputPayload.appId}`);
-        if (lastinputPayload.appId !== 'org.webosbrew.autostart') {
-          log("Relaunching this app...");
-          await lunaCall('luna://com.webos.service.applicationManager/launch', {
-            id: lastinputPayload.appId,
-          });
-        }
-      }
-    }
-    log("Done.");
   } catch (err) {
-    log(`An error occured:\n${err.stack}`);
+    log(`Couldn't setup overlay, stopping here:\n${err.stack}`);
+    return;
   }
+
+  try {
+    /* This just removes ourselves from the overlay, but we still live in the real /var/lib/eim,
+       which guarantees that we'll survive on the next reboot. */
+    await retry(3, async () => {
+      log('Unregistering ourselves as input app from the overlay...');
+      const res = await lunaCall('luna://com.webos.service.eim/deleteDevice', {
+        appId: 'org.webosbrew.autostart',
+      });
+      logres(res);
+    });
+  } catch (err) {
+    log(`Couldn't unregister, but carrying on:\n${err.stack}`);
+  }
+
+  log("Done.");
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "org.webosbrew.autostart",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "org.webosbrew.autostart",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Autostart test application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Autostart test application",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes the autostart for webOS 3.0, as explained in https://github.com/webosbrew/webos-homebrew-channel/issues/124#issuecomment-3370931998

I also added a GitHub workflow to automatically build and produce an artifact (`.ipk`) for each pull request. This artifact can be used to test/verify, and also copied over to a public release if needed, when code is merged to main. Artifacts are only downloadable by accounts with rights on the repository. If you're not comfortable with using GitHub actions for this repo, I can re-make the PR without the workflow.